### PR TITLE
Update json dependency

### DIFF
--- a/gnip-rule.gemspec
+++ b/gnip-rule.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency 'rest-client', '~> 1.6.7'
-  s.add_dependency 'json', '~> 1.7.7'
+  s.add_dependency 'json', '~> 1.8'
   s.add_dependency 'jruby-openssl' if RUBY_PLATFORM == 'java'
 end


### PR DESCRIPTION
Other gem's conflict with the current required version of json gem. This gem requires json ~> 1.7.7 while other gem's (such as twitter) require ~> 1.8 which causes a unsatisfiable conflict. gnip-rule should work just fine with requiring json ~> 1.8
